### PR TITLE
Handle errors in dns_server() without aborting

### DIFF
--- a/subfuz.py
+++ b/subfuz.py
@@ -115,7 +115,8 @@ if __name__ == "__main__":
         if not args.quiet: 
             print ("Scanning: %s" % domain)
         sf = SubFuz(domain, config, args, PLUGINS_DIR, CORE_DIR)
-        sf.dns_server()
+        if sf.dns_server() == False: 
+            continue
         sf.check_wildcard(sf.domain)
         sf.execute_plugins(plugins, sf)
         sf.scan()


### PR DESCRIPTION
If we hit an error for one of the domains in a multi-target scan, continue the loop instead of exiting.
This allows us to finish the scan for the valid entries.